### PR TITLE
Add prototype UI and server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+uploads/*
+!uploads/.gitkeep

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# contract_redliner
+# Contract Redliner
+
+This is a prototype web application that allows contract administrators to upload client contracts and compare them against a knowledge base using an AI model. The UI is built with Google's Material 3 web components.
+
+## Development
+
+1. Install dependencies (if desired):
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   node server.js
+   ```
+3. Open `http://localhost:3000` in your browser.
+
+The `knowledge_base` directory contains example contracts for the AI to reference. Uploaded client contracts are stored in the `uploads` directory.

--- a/knowledge_base/README.md
+++ b/knowledge_base/README.md
@@ -1,0 +1,1 @@
+Place client contracts here.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "contract_redliner",
+  "version": "0.1.0",
+  "description": "Contract comparison tool",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "multer": "^1.4.5"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Contract Redliner</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Roboto', sans-serif; margin: 2rem; }
+    #dropzone {
+      border: 2px dashed #ccc;
+      border-radius: 4px;
+      padding: 2rem;
+      text-align: center;
+      color: #666;
+    }
+  </style>
+</head>
+<body>
+  <h1>Contract Redliner</h1>
+  <div id="dropzone">Drag and drop a client contract here</div>
+  <br />
+  <md-filled-button id="compareBtn">Compare with Knowledge Base</md-filled-button>
+  <pre id="result"></pre>
+  <script type="module">
+    import 'https://unpkg.com/@material/web@1.0.0-rc.0/all.js?module';
+    const dropzone = document.getElementById('dropzone');
+    let uploadedFile;
+    dropzone.addEventListener('dragover', (e) => {
+      e.preventDefault();
+      dropzone.style.background = '#f5f5f5';
+    });
+    dropzone.addEventListener('dragleave', () => {
+      dropzone.style.background = 'transparent';
+    });
+    dropzone.addEventListener('drop', async (e) => {
+      e.preventDefault();
+      dropzone.style.background = 'transparent';
+      const file = e.dataTransfer.files[0];
+      if (file) {
+        const formData = new FormData();
+        formData.append('contract', file);
+        const res = await fetch('/api/upload', { method: 'POST', body: formData });
+        const data = await res.json();
+        uploadedFile = data.file;
+        dropzone.textContent = `Uploaded: ${file.name}`;
+      }
+    });
+
+    document.getElementById('compareBtn').addEventListener('click', async () => {
+      if (!uploadedFile) {
+        alert('Please upload a client contract first');
+        return;
+      }
+      const res = await fetch('/api/compare', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ uploadedFileName: uploadedFile })
+      });
+      const data = await res.json();
+      document.getElementById('result').textContent = data.result;
+    });
+  </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,42 @@
+const express = require('express');
+const multer = require('multer');
+const fs = require('fs');
+const path = require('path');
+const cors = require('cors');
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(cors());
+app.use(express.static('public'));
+app.use('/knowledge_base', express.static('knowledge_base'));
+
+const upload = multer({ dest: 'uploads/' });
+
+app.post('/api/upload', upload.single('contract'), (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: 'No file uploaded' });
+  }
+  res.json({ file: req.file.filename });
+});
+
+app.get('/api/contracts', (req, res) => {
+  fs.readdir('knowledge_base', (err, files) => {
+    if (err) {
+      return res.status(500).json({ error: 'Failed to list contracts' });
+    }
+    res.json({ files });
+  });
+});
+
+app.post('/api/compare', express.json(), async (req, res) => {
+  const { uploadedFileName, baseContractName } = req.body;
+  // TODO: integrate OpenAI ChatGPT 4.1 to compare contracts
+  // Placeholder response
+  const result = `Compared ${uploadedFileName} with ${baseContractName || 'default contract'}`;
+  res.json({ result });
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- build prototype Material 3 UI
- implement basic Express server for uploading and comparing contracts
- add README instructions and gitignore

## Testing
- `npm test`